### PR TITLE
Switch to more performatn CSS properties

### DIFF
--- a/flickr-zoom.css
+++ b/flickr-zoom.css
@@ -28,7 +28,3 @@ img.flickr-zoom.zoomed {
   border: none;
   max-width: none;
 }
-
-img.flickr-zoom.zoomed.smooth-panning {
-  transition: top 0.4s ease-out, left 0.4s ease-out;
-}

--- a/flickr-zoom.js
+++ b/flickr-zoom.js
@@ -52,14 +52,7 @@
 
       var called = 0;
       state.pan = function(mouseEvent) {
-        // On the first pan we want to snap the image into place, but on
-        // subsequent pans we want to transition the pan smoothly.  We
-        // only need to add the class once, on the second call.
-        if (++called === 2)
-          state.zoomed.classList.add('smooth-panning');
-
-        state.zoomed.style.left = mouseEvent.clientX * scaleX + "px";
-        state.zoomed.style.top  = mouseEvent.clientY * scaleY + "px";
+        state.zoomed.style.transform = "translate(" + mouseEvent.clientX * scaleX + "px, " + mouseEvent.clientY * scaleY + "px)";
       };
 
       // Pan to match initial click position…


### PR DESCRIPTION
Hi there, cool little script. Using the transform property is usually a better idea when moving around elements with CSS, especially when animating. However, I find it more responsive w/ CSS transition.