### PR TITLE
Use CSS transition instead of animating left/right

### DIFF
--- a/flickr-zoom.css
+++ b/flickr-zoom.css
@@ -30,5 +30,5 @@ img.flickr-zoom.zoomed {
 }
 
 img.flickr-zoom.zoomed.smooth-panning {
-  transition: top 0.4s ease-out, left 0.4s ease-out;
+  transition: transform .4s ease-out;
 }

--- a/flickr-zoom.js
+++ b/flickr-zoom.js
@@ -75,8 +75,7 @@ document.addEventListener("DOMContentLoaded", function() {
             scaleX = -1 / screenW * (zoomW - screenW),
             scaleY = -1 / screenH * (zoomH - screenH);
 
-        state.zoomed.style.left = mouseEvent.clientX * scaleX + "px";
-        state.zoomed.style.top  = mouseEvent.clientY * scaleY + "px";
+        state.zoomed.style.transform = "translate(" + mouseEvent.clientX * scaleX + "px, " + mouseEvent.clientY * scaleY + "px)";
       };
 
       // Pan to match initial click position.

--- a/flickr-zoom.js
+++ b/flickr-zoom.js
@@ -22,6 +22,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
     clickEvent.preventDefault();
 
+    var initialPanSetTimeoutId;
+
     // Viewport dimensions may change between clicks, so fetch them each time.
     var screenW = document.documentElement.clientWidth,
         screenH = document.documentElement.clientHeight;
@@ -32,17 +34,29 @@ document.addEventListener("DOMContentLoaded", function() {
       state.zoomed = target.cloneNode(false);
       state.zoomed.removeAttribute("id");
       state.zoomed.classList.add('zoomed');
+      state.zoomed.addEventListener("load", panAndZoom)
       document.body.appendChild(state.zoomed);
       document.body.appendChild(state.screen);
 
+    }
+    else {
+      // Remove listener, possible setTimeout event and remove cloned image, reseting our state
+      window.removeEventListener('mousemove', state.pan, false);
+      clearTimeout(initialPanSetTimeoutId);
+      state.zoomed.removeEventListener("load", panAndZoom);
+      state.zoomed.parentNode.removeChild(state.zoomed);
+      state.screen.parentNode.removeChild(state.screen);
+      state = initialState();
+    }
+
+    function panAndZoom() {
       var naturalW = state.zoomed.naturalWidth,
           naturalH = state.zoomed.naturalHeight;
 
       state.zoomed.setAttribute("width",  naturalW);
       state.zoomed.setAttribute("height", naturalH);
 
-      var called = 0,
-          initialPanSetTimeoutId;
+      var called = 0;
       state.pan = function(mouseEvent) {
         // On the first pan we want to snap the image into place, but on
         // subsequent pans we want to transition the pan smoothly.  We
@@ -80,14 +94,6 @@ document.addEventListener("DOMContentLoaded", function() {
       // than the viewport.
       if (naturalW > screenW || naturalH > screenH)
         window.addEventListener('mousemove', state.pan, false);
-    }
-    else {
-      // Remove listener, possible setTimeout event and remove cloned image, reseting our state
-      window.removeEventListener('mousemove', state.pan, false);
-      clearTimeout(initialPanSetTimeoutId);
-      state.zoomed.parentNode.removeChild(state.zoomed);
-      state.screen.parentNode.removeChild(state.screen);
-      state = initialState();
     }
 
   }, false);


### PR DESCRIPTION
This is inspired by PR #2, but based on my safari-fix branch.

At least in 2021 CSS transitions are animatable and performance in Safari (version 13) got much better after these changes.