### PR TITLE
Disable scrolling of body when flickr-zoom is in progress

### DIFF
--- a/flickr-zoom.css
+++ b/flickr-zoom.css
@@ -1,3 +1,7 @@
+body.flickr-zoom.zoomed {
+  overflow: hidden !important;
+}
+
 div.flickr-zoom-screen {
   z-index: 10000;
   position: fixed;

--- a/flickr-zoom.js
+++ b/flickr-zoom.js
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", function() {
       state.zoomed.addEventListener("load", panAndZoom)
       document.body.appendChild(state.zoomed);
       document.body.appendChild(state.screen);
-
+      document.body.classList.add("flickr-zoom", "zoomed");
     }
     else {
       // Remove listener, possible setTimeout event and remove cloned image, reseting our state
@@ -46,6 +46,7 @@ document.addEventListener("DOMContentLoaded", function() {
       state.zoomed.removeEventListener("load", panAndZoom);
       state.zoomed.parentNode.removeChild(state.zoomed);
       state.screen.parentNode.removeChild(state.screen);
+      document.body.classList.remove("flickr-zoom", "zoomed");
       state = initialState();
     }
 


### PR DESCRIPTION
Disable scrolling of `body` element when large image panning is in progress to avoid a weird situation where user scrolls while panning and sees scrollbar (when image is not too large) to move in the background.